### PR TITLE
Ajuste para instalação do kind no mecOS.

### DIFF
--- a/semana1/README.md
+++ b/semana1/README.md
@@ -429,7 +429,7 @@ O Kind (*Kubernetes in Docker*) é outra alternativa para executar o Kubernetes 
 Para fazer a instalação no GNU/Linux, execute os seguintes comandos.
 
 ```
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
 
 chmod +x ./kind
 
@@ -447,7 +447,7 @@ sudo brew install kind
 ou
 
 ```
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-darwin-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-darwin-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 ```
@@ -457,7 +457,7 @@ mv ./kind /usr/local/bin/kind
 Para fazer a instalação no Windows, execute os seguintes comandos.
 
 ```
-curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.14.0/kind-windows-amd64
+curl.exe -Lo kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.20.0/kind-windows-amd64
 
 Move-Item .\kind-windows-amd64.exe c:\kind.exe
 ```


### PR DESCRIPTION
Alterado para instalação da nova versão do kind 0.20.0;
Na instalação do kind para mecOS o arquivo deve ser movido para o path: /usr/local/bin/kind